### PR TITLE
Use error source fixed

### DIFF
--- a/src/error_chain.rs
+++ b/src/error_chain.rs
@@ -1,48 +1,51 @@
 #[doc(hidden)]
 #[macro_export]
 #[cfg(not(has_error_source))]
-macro_rules! impl_error_chain_source {
+macro_rules! impl_error_chain_cause_or_source {
     (
-     types {
+        types {
             $error_kind_name:ident
-    }
-    foreign_links {
-        $( $foreign_link_variant:ident ( $foreign_link_error_path:path )
-            $( #[$meta_foreign_links:meta] )*; )*
-    }) => {
+        }
 
-    #[allow(unknown_lints, renamed_and_removed_lints, unused_doc_comment, unused_doc_comments)]
-    fn cause(&self) -> Option<&::std::error::Error> {
-        match self.1.next_error {
-            Some(ref c) => Some(&**c),
-            None => {
-                match self.0 {
-                    $(
-                        $(#[$meta_foreign_links])*
-                        $error_kind_name::$foreign_link_variant(ref foreign_err) => {
-                        foreign_err.cause()
-                        }
-                    ) *
-                _ => None
+        foreign_links {
+            $( $foreign_link_variant:ident ( $foreign_link_error_path:path )
+               $( #[$meta_foreign_links:meta] )*; )*
+        }
+    ) => {
+        #[allow(unknown_lints, renamed_and_removed_lints, unused_doc_comment, unused_doc_comments)]
+        fn cause(&self) -> Option<&::std::error::Error> {
+            match self.1.next_error {
+                Some(ref c) => Some(&**c),
+                None => {
+                    match self.0 {
+                        $(
+                            $(#[$meta_foreign_links])*
+                            $error_kind_name::$foreign_link_variant(ref foreign_err) => {
+                                foreign_err.cause()
+                            }
+                        ) *
+                        _ => None
+                    }
                 }
             }
         }
-    }
     };
 }
 
 #[cfg(has_error_source)]
 #[doc(hidden)]
 #[macro_export]
-macro_rules! impl_error_chain_source {
+macro_rules! impl_error_chain_cause_or_source {
     (
-     types {
-            $error_kind_name:ident
-    }
-    foreign_links {
-        $( $foreign_link_variant:ident ( $foreign_link_error_path:path )
-            $( #[$meta_foreign_links:meta] )*; )*
-    }) => {
+        types {
+             $error_kind_name:ident
+        }
+
+        foreign_links {
+            $( $foreign_link_variant:ident ( $foreign_link_error_path:path )
+               $( #[$meta_foreign_links:meta] )*; )*
+        }
+    ) => {
 
             #[allow(unknown_lints, renamed_and_removed_lints, unused_doc_comment, unused_doc_comments)]
             fn source(&self) -> Option<&(std::error::Error + 'static)> {
@@ -245,7 +248,7 @@ macro_rules! impl_error_chain_processed {
                 self.description()
             }
 
-            $crate::impl_error_chain_source!{
+            $crate::impl_error_chain_cause_or_source!{
                 types {
                     $error_kind_name
                 }

--- a/src/error_chain.rs
+++ b/src/error_chain.rs
@@ -248,7 +248,7 @@ macro_rules! impl_error_chain_processed {
                 self.description()
             }
 
-            $crate::impl_error_chain_cause_or_source!{
+            impl_error_chain_cause_or_source!{
                 types {
                     $error_kind_name
                 }

--- a/src/error_chain.rs
+++ b/src/error_chain.rs
@@ -1,3 +1,69 @@
+#[doc(hidden)]
+#[macro_export]
+#[cfg(not(has_error_source))]
+macro_rules! impl_error_chain_source {
+    (
+     types {
+            $error_kind_name:ident
+    }
+    foreign_links {
+        $( $foreign_link_variant:ident ( $foreign_link_error_path:path )
+            $( #[$meta_foreign_links:meta] )*; )*
+    }) => {
+
+    #[allow(unknown_lints, renamed_and_removed_lints, unused_doc_comment, unused_doc_comments)]
+    fn cause(&self) -> Option<&::std::error::Error> {
+        match self.1.next_error {
+            Some(ref c) => Some(&**c),
+            None => {
+                match self.0 {
+                    $(
+                        $(#[$meta_foreign_links])*
+                        $error_kind_name::$foreign_link_variant(ref foreign_err) => {
+                        foreign_err.cause()
+                        }
+                    ) *
+                _ => None
+                }
+            }
+        }
+    }
+    };
+}
+
+#[cfg(has_error_source)]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! impl_error_chain_source {
+    (
+     types {
+            $error_kind_name:ident
+    }
+    foreign_links {
+        $( $foreign_link_variant:ident ( $foreign_link_error_path:path )
+            $( #[$meta_foreign_links:meta] )*; )*
+    }) => {
+
+            #[allow(unknown_lints, renamed_and_removed_lints, unused_doc_comment, unused_doc_comments)]
+            fn source(&self) -> Option<&(std::error::Error + 'static)> {
+                match self.1.next_error {
+                    Some(ref c) => Some(&**c),
+                    None => {
+                        match self.0 {
+                        $(
+                            $(#[$meta_foreign_links])*
+                            $error_kind_name::$foreign_link_variant(ref foreign_err) => {
+                                foreign_err.source()
+                            }
+                        ) *
+                            _ => None
+                        }
+                    }
+                }
+            }
+        };
+}
+
 /// Prefer to use `error_chain` instead of this macro.
 #[doc(hidden)]
 #[macro_export]
@@ -179,41 +245,13 @@ macro_rules! impl_error_chain_processed {
                 self.description()
             }
 
-            #[cfg(not(has_error_source))]
-            #[allow(unknown_lints, renamed_and_removed_lints, unused_doc_comment, unused_doc_comments)]
-            fn cause(&self) -> Option<&::std::error::Error> {
-                match self.1.next_error {
-                    Some(ref c) => Some(&**c),
-                    None => {
-                        match self.0 {
-                            $(
-                                $(#[$meta_foreign_links])*
-                                $error_kind_name::$foreign_link_variant(ref foreign_err) => {
-                                    foreign_err.cause()
-                                }
-                            ) *
-                            _ => None
-                        }
-                    }
+            $crate::impl_error_chain_source!{
+                types {
+                    $error_kind_name
                 }
-            }
-
-            #[cfg(has_error_source)]
-            #[allow(unknown_lints, renamed_and_removed_lints, unused_doc_comment, unused_doc_comments)]
-            fn source(&self) -> Option<&(std::error::Error + 'static)> {
-                match self.1.next_error {
-                    Some(ref c) => Some(&**c),
-                    None => {
-                        match self.0 {
-                            $(
-                                $(#[$meta_foreign_links])*
-                                $error_kind_name::$foreign_link_variant(ref foreign_err) => {
-                                    foreign_err.source()
-                                }
-                            ) *
-                            _ => None
-                        }
-                    }
+                foreign_links {
+                    $( $foreign_link_variant ( $foreign_link_error_path )
+                    $( #[$meta_foreign_links] )*; )*
                 }
             }
         }


### PR DESCRIPTION
This fixes your fix https://github.com/rust-lang-nursery/error-chain/pull/255 ;)
It moves usage of `has_error_source` flag outside the macro, otherwise it will break compilation in dependent crates as they do not have this flag defined.
